### PR TITLE
fix: ios onReceivePayload 返回参数更改

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.2.2
+1. ios onReceivePayload 返回参数更改
+
+## 0.2.1
+1.新增setLocalBadge接口
+
+* TODO: Describe initial release.
+
 ## 0.1.9
 
 1.新增bindAlias& unbindAlias &setBadge & resetBadge接口
@@ -5,8 +13,3 @@
 3.完善readme
 4.添加支持静态库
 5.修复已知问题
-
-## 0.2.1
-1.新增setLocalBadge接口
-
-* TODO: Describe initial release.

--- a/ios/Classes/GetuiflutPlugin.m
+++ b/ios/Classes/GetuiflutPlugin.m
@@ -246,7 +246,7 @@
     if (payloadData) {
         payloadMsg = [[NSString alloc] initWithBytes:payloadData.bytes length:payloadData.length encoding:NSUTF8StringEncoding];
     }
-    NSDictionary *payloadMsgDic = @{@"payloadMsg" : payloadMsg, @"offLine" : @(offLine)};
+    NSDictionary *payloadMsgDic = @{@"payload" : payloadMsg, @"offLine" : @(offLine), @"taskId": taskId};
     [_channel invokeMethod:@"onReceivePayload" arguments:payloadMsgDic];
     NSLog(@"%@",payloadMsg);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: getuiflut
 description: getui flutter plugin
-version: 0.2.1
+version: 0.2.2
 homepage: https://www.getui.com
 
 environment:


### PR DESCRIPTION
1. 更改ios[payloadMsg]字段名为[payload],使android与ios保持一致,同时增加taskId

![原字段](https://user-images.githubusercontent.com/24207813/83832165-9987f080-a71b-11ea-84f3-910e925508d8.png)
上图的字段变更为下图形式
![现字段](https://user-images.githubusercontent.com/24207813/83832174-9ee53b00-a71b-11ea-921a-52bdc36a6bc1.png)
