### PR TITLE
Namespace not specified

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,7 @@ rootProject.allprojects {
 }
 apply plugin: 'com.android.library'
 android {
+    namespace 'com.getui.getuiflut'
     compileSdkVersion 28
 
     defaultConfig {


### PR DESCRIPTION
A problem occurred configuring project ':getuiflut'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

     If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.


https://github.com/GetuiLaboratory/getui-flutter-plugin/issues/65